### PR TITLE
chore: updating alert dialog to be reusable

### DIFF
--- a/app/src/main/java/br/com/ascence/anotei/ui/screens/note/NoteScreen.kt
+++ b/app/src/main/java/br/com/ascence/anotei/ui/screens/note/NoteScreen.kt
@@ -30,7 +30,7 @@ import br.com.ascence.anotei.ui.common.components.noteoptions.NoteOptionsBar
 import br.com.ascence.anotei.ui.presentation.NoteOptionsPresentationType
 import br.com.ascence.anotei.ui.screens.note.components.NoteAppBar
 import br.com.ascence.anotei.ui.screens.note.components.NoteHeader
-import br.com.ascence.anotei.ui.screens.note.dialogs.ContentAlertDialog
+import br.com.ascence.anotei.ui.screens.note.dialogs.SimpleDialog
 import br.com.ascence.anotei.ui.theme.AnoteiAppTheme
 import br.com.ascence.anotei.ui.theme.AnoteiTheme
 
@@ -82,7 +82,11 @@ fun NoteScreenContent(
                 .background(AnoteiAppTheme.colors.colorScheme.background)
         ) {
             if (state.value.showContentAlert) {
-                ContentAlertDialog(
+                SimpleDialog(
+                    title = "Descartar nota?",
+                    message = "Deseja descartar o que anotou até o momento?",
+                    confirmLabel = "Confirmar",
+                    dismissLabel = "Cancelar",
                     onDismiss = { viewModel.hideContentAlertDialog() },
                     onConfirm = { onBackPressed(NOTE_RESULT_NOTHING) }
                 )

--- a/app/src/main/java/br/com/ascence/anotei/ui/screens/note/dialogs/ContentAlertDialog.kt
+++ b/app/src/main/java/br/com/ascence/anotei/ui/screens/note/dialogs/ContentAlertDialog.kt
@@ -9,33 +9,63 @@ import br.com.ascence.anotei.ui.theme.AnoteiAppTheme
 import br.com.ascence.anotei.ui.theme.AnoteiTheme
 
 @Composable
-fun ContentAlertDialog(onDismiss: () -> Unit, onConfirm: () -> Unit) {
+fun SimpleDialog(
+    title: String,
+    message: String,
+    onConfirm: () -> Unit,
+    confirmLabel: String,
+    onDismiss: () -> Unit,
+    dismissLabel: String? = null,
+) {
     AlertDialog(
+        title = { Text(text = title) },
+        text = { Text(text = message) },
+        titleContentColor = AnoteiAppTheme.colors.primaryTextColor,
+        textContentColor = AnoteiAppTheme.colors.secondaryTextColor,
         onDismissRequest = onDismiss,
+        dismissButton = {
+            dismissLabel?.let { actionLabel ->
+                TextButton(
+                    content = { Text(actionLabel, color = AnoteiAppTheme.colors.accentColor) },
+                    onClick = onDismiss
+                )
+            }
+        },
         confirmButton = {
             TextButton(
-                content = { Text("Confirmar", color = AnoteiAppTheme.colors.accentColor) },
+                content = { Text(confirmLabel, color = AnoteiAppTheme.colors.accentColor) },
                 onClick = onConfirm
             )
         },
-        title = { Text(text = "Descartar nota?") },
-        text = { Text("Você deseja descartar o que anotou até agora?") },
-        dismissButton = {
-            TextButton(
-                content = { Text("Cancelar", color = AnoteiAppTheme.colors.accentColor) },
-                onClick = onDismiss
-            )
-        },
         containerColor = AnoteiAppTheme.colors.secondaryBackgroundColor,
-        titleContentColor = AnoteiAppTheme.colors.primaryTextColor,
-        textContentColor = AnoteiAppTheme.colors.secondaryTextColor
     )
 }
 
 @Composable
 @ColorSchemePreviews
-private fun ContentAlertDialogPreview() {
+private fun SimpleAlertDialogWithDismissPreview() {
     AnoteiTheme {
-        ContentAlertDialog(onDismiss = {}, onConfirm = {})
+        SimpleDialog(
+            title = "Descartar nota?",
+            message = "Você deseja descartar o que anotou até agora?",
+            confirmLabel = "Confirmar",
+            dismissLabel = "Cancelar",
+            onDismiss = {},
+            onConfirm = {}
+        )
+    }
+}
+
+@Composable
+@ColorSchemePreviews
+private fun SimpleAlertDialogWithoutDismissPreview() {
+    AnoteiTheme {
+        SimpleDialog(
+            title = "Um momento!",
+            message = "Anote alguma coisa antes de salvar.",
+            confirmLabel = "Confirmar",
+            onDismiss = {},
+            onConfirm = {}
+        )
     }
 }


### PR DESCRIPTION
### Pull Request description

Atualizando o componente de alert pra ser reutilizável


### Visual Evidences

<!--  To set imagens or videos  use
<img width = 300 src ="link of the image">
<video src ="link of the video">
-->

<!-- To set tables use
| column_title | column_title |
| --- | --- |
| row_content | row_content |
| row_content | row_content |
-->



### Checklist before merge

- [x] PR labels set
- [ ] Evidence of changes
- [ ] Unit Tests made (if necessary)
- [ ] UI tests made (if necessary)