### PR TITLE
chore: refactoring note screen to suport display and edit mode part 1

### DIFF
--- a/app/src/main/java/br/com/ascence/anotei/navigation/DestinationPaths.kt
+++ b/app/src/main/java/br/com/ascence/anotei/navigation/DestinationPaths.kt
@@ -2,6 +2,7 @@ package br.com.ascence.anotei.navigation
 
 //ARGUMENTS
 const val NOTE_ID_ARG = "noteId"
+const val NOTE_TYPE_ARG = "noteType"
 
 // PATHS
 const val DASHBOARD_PATH = "dashboard"

--- a/app/src/main/java/br/com/ascence/anotei/navigation/NavigationRoot.kt
+++ b/app/src/main/java/br/com/ascence/anotei/navigation/NavigationRoot.kt
@@ -8,21 +8,26 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import br.com.ascence.anotei.navigation.activitycontracts.newnote.NoteType
 import br.com.ascence.anotei.ui.screens.dashboard.DashboardScreen
-import br.com.ascence.anotei.ui.screens.noteDisplay.NoteDisplay
+import br.com.ascence.anotei.ui.screens.note.NoteScreenContent
 
 @Composable
 fun SetupAppNavigation(navController: NavHostController) {
     NavHost(navController = navController, startDestination = CScreens.DASHBOARD.routePath) {
         composable(
             route = CScreens.DASHBOARD.routePath
-        ) {
-            DashboardScreen(navController = navController)
+        ) { backStepEntry ->
+            DashboardScreen(
+                navBackStackEntry = backStepEntry,
+                navController = navController
+            )
         }
         composable(
-            route = "${CScreens.NOTE_DISPLAY.routePath}/{$NOTE_ID_ARG}",
+            route = "${CScreens.NOTE_DISPLAY.routePath}/{$NOTE_ID_ARG}/{$NOTE_TYPE_ARG}",
             arguments = listOf(
-                navArgument(NOTE_ID_ARG) { type = NavType.StringType }
+                navArgument(NOTE_ID_ARG) { type = NavType.StringType },
+                navArgument(NOTE_TYPE_ARG) { type = NavType.StringType }
             ),
             enterTransition = {
                 return@composable slideIntoContainer(
@@ -35,7 +40,41 @@ fun SetupAppNavigation(navController: NavHostController) {
                 )
             }
         ) { backStepEntry ->
-            NoteDisplay(noteId = backStepEntry.arguments?.getString(NOTE_ID_ARG))
+            val noteTypeArg = backStepEntry.arguments?.getString(NOTE_TYPE_ARG)
+            val noteType = NoteType.entries.firstOrNull {
+                it.name == noteTypeArg
+            } ?: NoteType.DISPLAY_NOTE
+            NoteScreenContent(
+                navController = navController,
+                noteType = noteType,
+                noteId = backStepEntry.arguments?.getString(NOTE_ID_ARG)
+            )
+        }
+        composable(
+            route = "${CScreens.NOTE_DISPLAY.routePath}/{$NOTE_TYPE_ARG}",
+            arguments = listOf(
+                navArgument(NOTE_TYPE_ARG) { type = NavType.StringType }
+            ),
+            enterTransition = {
+                return@composable slideIntoContainer(
+                    AnimatedContentTransitionScope.SlideDirection.Up, tween(500)
+                )
+            },
+            popExitTransition = {
+                return@composable slideOutOfContainer(
+                    AnimatedContentTransitionScope.SlideDirection.Down, tween(500)
+                )
+            }
+        ) { backStepEntry ->
+            val noteTypeArg = backStepEntry.arguments?.getString(NOTE_TYPE_ARG)
+            val noteType = NoteType.entries.firstOrNull {
+                it.name == noteTypeArg
+            } ?: NoteType.NEW_NOTE
+            NoteScreenContent(
+                navController = navController,
+                noteType = noteType,
+                noteId = null
+            )
         }
     }
 }

--- a/app/src/main/java/br/com/ascence/anotei/navigation/activitycontracts/newnote/NoteType.kt
+++ b/app/src/main/java/br/com/ascence/anotei/navigation/activitycontracts/newnote/NoteType.kt
@@ -2,5 +2,6 @@ package br.com.ascence.anotei.navigation.activitycontracts.newnote
 
 enum class NoteType {
     NEW_NOTE,
-    UPDATE_NOTE
+    UPDATE_NOTE,
+    DISPLAY_NOTE,
 }

--- a/app/src/main/java/br/com/ascence/anotei/navigation/extensions/NavControllerExt.kt
+++ b/app/src/main/java/br/com/ascence/anotei/navigation/extensions/NavControllerExt.kt
@@ -3,7 +3,12 @@ package br.com.ascence.anotei.navigation.extensions
 import androidx.navigation.NavController
 import br.com.ascence.anotei.navigation.CScreens
 
-fun <T> NavController.navigateForResultOnce(key: String, onResult: (T) -> Unit) {
+fun <T> NavController.navigateForResultOnce(
+    screen: CScreens,
+    args: List<String>,
+    key: String,
+    onResult: (T) -> Unit,
+) {
     val screenResult = currentBackStackEntry
         ?.savedStateHandle
         ?.get<T>(key)
@@ -15,14 +20,15 @@ fun <T> NavController.navigateForResultOnce(key: String, onResult: (T) -> Unit) 
             ?.savedStateHandle
             ?.remove<T>(key)
     }
+
+    navigateWithArgs(screen, args)
 }
 
 fun <T> NavController.popBackStackWithResult(key: String, value: T) {
+    popBackStack()
     currentBackStackEntry
         ?.savedStateHandle
         ?.set(key, value)
-
-    popBackStack()
 }
 
 fun NavController.navigateWithArgs(screen: CScreens, args: List<String>) {

--- a/app/src/main/java/br/com/ascence/anotei/navigation/extensions/NoteTypeExt.kt
+++ b/app/src/main/java/br/com/ascence/anotei/navigation/extensions/NoteTypeExt.kt
@@ -6,5 +6,5 @@ import br.com.ascence.anotei.ui.common.components.noteoptions.presentation.NoteO
 internal fun NoteType.toNoteOptionsMode() =
     when (this) {
         NoteType.NEW_NOTE -> NoteOptionsMode.CREATE_MODE
-        NoteType.UPDATE_NOTE -> NoteOptionsMode.EDIT_MODE
+        NoteType.UPDATE_NOTE, NoteType.DISPLAY_NOTE -> NoteOptionsMode.EDIT_MODE
     }

--- a/app/src/main/java/br/com/ascence/anotei/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/br/com/ascence/anotei/ui/screens/dashboard/DashboardScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import br.com.ascence.anotei.data.local.AnoteiDatabase
 import br.com.ascence.anotei.data.local.implementations.NotesRepositoryImp
@@ -25,6 +26,7 @@ import br.com.ascence.anotei.model.NoteOption
 import br.com.ascence.anotei.navigation.CScreens
 import br.com.ascence.anotei.navigation.NOTE_RESULT_CREATED_OR_UPDATED
 import br.com.ascence.anotei.navigation.NOTE_RESULT_NOTHING
+import br.com.ascence.anotei.navigation.NOTE_TYPE_EXTRA
 import br.com.ascence.anotei.navigation.activitycontracts.newnote.NewNoteActivityResultContract
 import br.com.ascence.anotei.navigation.activitycontracts.newnote.NoteType
 import br.com.ascence.anotei.navigation.extensions.navigateWithArgs
@@ -38,6 +40,7 @@ import br.com.ascence.anotei.ui.theme.AnoteiTheme
 
 @Composable
 fun DashboardScreen(
+    navBackStackEntry: NavBackStackEntry,
     navController: NavController,
 ) {
     val contextCompat = LocalContext.current
@@ -58,8 +61,8 @@ fun DashboardScreen(
         onResult = { result ->
             when (result) {
                 NOTE_RESULT_CREATED_OR_UPDATED -> {
-                   viewModel.fetchNotes()
-                   viewModel.resetListScrollState()
+                    viewModel.fetchNotes()
+                    viewModel.resetListScrollState()
                 }
                 NOTE_RESULT_NOTHING -> println(">>>>>>>> NOTHING")
             }
@@ -76,6 +79,12 @@ fun DashboardScreen(
         viewModel.fetchNotes()
     }
 
+    LaunchedEffect(key1 = navBackStackEntry.savedStateHandle) {
+        navBackStackEntry.savedStateHandle.get<String>(NOTE_TYPE_EXTRA)?.let { result ->
+            println(">>>>>> SCREEN RESULT $result") // TODO SETUP SCREEN RESULT
+        }
+    }
+
     DashBoardContent(
         notesList = state.notesList,
         showNoteOptions = state.showNoteOptions,
@@ -87,7 +96,7 @@ fun DashboardScreen(
             } else {
                 navController.navigateWithArgs(
                     screen = CScreens.NOTE_DISPLAY,
-                    args = listOf(note.id.toString())
+                    args = listOf(note.id.toString(), NoteType.DISPLAY_NOTE.name)
                 )
             }
         },
@@ -96,7 +105,10 @@ fun DashboardScreen(
             viewModel.toggleSelectionMode(true)
         },
         onNewNoteClick = {
-            noteScreen.launch(NoteType.NEW_NOTE)
+            navController.navigateWithArgs(
+                screen = CScreens.NOTE_DISPLAY,
+                args = listOf(NoteType.NEW_NOTE.name)
+            )
         },
         onAlterNoteClick = {
             noteScreen.launch(NoteType.UPDATE_NOTE)

--- a/app/src/main/java/br/com/ascence/anotei/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/br/com/ascence/anotei/ui/screens/dashboard/DashboardViewModel.kt
@@ -106,7 +106,7 @@ class DashboardViewModel(
         }
     }
 
-    private fun handleNoteDeletion(){
+    private fun handleNoteDeletion() {
 
         val isSelectionModeActivated = _uiState.value.isSelectionModeActivated
 
@@ -120,7 +120,7 @@ class DashboardViewModel(
 
     private fun handleSimpleNoteSelection(note: Note) {
         _uiState.update { currentState ->
-            currentState.copy(selectedNoteList = listOf(note), showNoteOptions = true)
+            currentState.copy(selectedNoteList = listOf(note))
         }
     }
 

--- a/app/src/main/java/br/com/ascence/anotei/ui/screens/note/NoteActivity.kt
+++ b/app/src/main/java/br/com/ascence/anotei/ui/screens/note/NoteActivity.kt
@@ -25,12 +25,12 @@ class NoteActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             AnoteiTheme {
-                NoteScreenContent(
-                    noteType = noteType,
-                    note = note,
-                ) { result ->
-                    finishWithResult(result)
-                }
+//                NoteScreenContent(
+//                    noteType = noteType,
+//                    noteId = note.id,
+//                ) { result ->
+//                    finishWithResult(result)
+//                }
             }
         }
     }

--- a/app/src/main/java/br/com/ascence/anotei/ui/screens/note/NoteScreen.kt
+++ b/app/src/main/java/br/com/ascence/anotei/ui/screens/note/NoteScreen.kt
@@ -5,18 +5,22 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -24,15 +28,14 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.navigation.NavController
 import br.com.ascence.anotei.data.local.AnoteiDatabase
 import br.com.ascence.anotei.data.local.implementations.NotesRepositoryImp
 import br.com.ascence.anotei.data.preview.ColorSchemePreviews
-import br.com.ascence.anotei.model.Note
 import br.com.ascence.anotei.model.extension.getColor
-import br.com.ascence.anotei.navigation.NOTE_RESULT_NOTHING
+import br.com.ascence.anotei.navigation.NOTE_TYPE_EXTRA
 import br.com.ascence.anotei.navigation.activitycontracts.newnote.NoteType
-import br.com.ascence.anotei.navigation.extensions.toNoteOptionsMode
-import br.com.ascence.anotei.ui.common.components.noteoptions.NoteOptionsWidget
+import br.com.ascence.anotei.navigation.extensions.popBackStackWithResult
 import br.com.ascence.anotei.ui.common.components.popup.AppPopup
 import br.com.ascence.anotei.ui.common.components.popup.contents.NoteCategorySelection
 import br.com.ascence.anotei.ui.screens.note.NoteScreenViewModel.Companion.TITLE_MAX_LENGTH
@@ -46,9 +49,9 @@ import java.util.Date
 
 @Composable
 fun NoteScreenContent(
+    navController: NavController,
     noteType: NoteType,
-    note: Note.TextNote?,
-    onBackPressed: (String) -> Unit,
+    noteId: String?,
 ) {
 
     val contextCompat = LocalContext.current
@@ -79,15 +82,19 @@ fun NoteScreenContent(
         when (noteType) {
             NoteType.NEW_NOTE -> {
                 viewModel.fetchNoteContent(noteType)
-                focusRequester.requestFocus()
             }
 
-            NoteType.UPDATE_NOTE -> viewModel.fetchNoteContent(noteType, note)
+            NoteType.UPDATE_NOTE, NoteType.DISPLAY_NOTE -> viewModel.fetchNoteContent(
+                noteType,
+                noteId
+            )
         }
     }
 
     BackHandler(enabled = state.showContentAlert.not()) {
-        viewModel.handleOnBackPressed(noteType, onBackPressed)
+        viewModel.handleOnBackPressed(
+            noteType
+        ) { result -> navController.popBackStackWithResult(NOTE_TYPE_EXTRA, result) }
     }
 
     Scaffold(
@@ -98,108 +105,145 @@ fun NoteScreenContent(
             .imePadding(),
         topBar = {
             NoteAppBar {
-                viewModel.handleOnBackPressed(noteType, onBackPressed)
+                viewModel.handleOnBackPressed(
+                    noteType
+                ) { result -> navController.popBackStackWithResult(NOTE_TYPE_EXTRA, result) }
             }
         },
         bottomBar = {
-            NoteOptionsWidget(
-                mode = noteType.toNoteOptionsMode(),
-                selectedNotes = listOfNotNull(note),
-                onOptionClick = { noteOption -> viewModel.handleNoteOptionClick(noteOption) },
-                onFABClick = {
-                    viewModel.handleNote(
-                        noteType = noteType,
-                        note = note,
-                        onSaveNote = { result -> onBackPressed(result) }
-                    )
-                },
-            )
+//            NoteOptionsWidget(
+//                mode = noteType.toNoteOptionsMode(),
+//                selectedNotes = listOfNotNull(note),
+//                onOptionClick = { noteOption -> viewModel.handleNoteOptionClick(noteOption) },
+//                onFABClick = {
+//                    viewModel.handleNote(
+//                        noteType = noteType,
+//                        note = note,
+//                        onSaveNote = { result -> onBackPressed(result) }
+//                    )
+//                },
+//            )
         }
     ) { innerPadding ->
 
-        Column(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
                 .background(AnoteiAppTheme.colors.colorScheme.background)
         ) {
-            if (state.showContentAlert) {
-                SimpleDialog(
-                    title = "Descartar nota?",
-                    message = "Deseja descartar o que anotou até o momento?",
-                    confirmLabel = "Confirmar",
-                    dismissLabel = "Cancelar",
-                    onDismiss = { viewModel.hideAlertDialog() },
-                    onConfirm = { onBackPressed(NOTE_RESULT_NOTHING) }
-                )
-            }
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .align(Alignment.Center)
+            ) {
+                if (state.showContentAlert) {
+                    SimpleDialog(
+                        title = "Descartar nota?",
+                        message = "Deseja descartar o que anotou até o momento?",
+                        confirmLabel = "Confirmar",
+                        dismissLabel = "Cancelar",
+                        onDismiss = { viewModel.hideAlertDialog() },
+                        onConfirm = {
+                            viewModel.dismissContentAlertDialog(
+                                noteType,
+                                noteId
+                            ) { result ->
+                                navController.popBackStackWithResult(
+                                    NOTE_TYPE_EXTRA,
+                                    result
+                                )
+                            }
+                        }
+                    )
+                }
 
-            if (state.showEmptyNoteAlert) {
-                SimpleDialog(
-                    title = "Um momento!",
-                    message = "Anote alguma coisa antes de salvar.",
-                    confirmLabel = "Entendi",
-                    onDismiss = { viewModel.hideAlertDialog() },
-                    onConfirm = { viewModel.hideAlertDialog() }
-                )
-            }
+                if (state.showEmptyNoteAlert) {
+                    SimpleDialog(
+                        title = "Um momento!",
+                        message = "Anote alguma coisa antes de salvar.",
+                        confirmLabel = "Entendi",
+                        onDismiss = { viewModel.hideAlertDialog() },
+                        onConfirm = { viewModel.hideAlertDialog() }
+                    )
+                }
 
-            if (state.showNoteDiscardAlert) {
-                SimpleDialog(
-                    title = "Descartar nota",
-                    message = "Deseja realmente descartar esta nota?",
-                    confirmLabel = "Confirmar",
-                    dismissLabel = "Cancelar",
-                    onDismiss = { viewModel.hideAlertDialog() },
-                    onConfirm = { viewModel.hideAlertDialog() }
-                )
-            }
+                if (state.showNoteDiscardAlert) {
+                    SimpleDialog(
+                        title = "Descartar nota",
+                        message = "Deseja realmente descartar esta nota?",
+                        confirmLabel = "Confirmar",
+                        dismissLabel = "Cancelar",
+                        onDismiss = { viewModel.hideAlertDialog() },
+                        onConfirm = { viewModel.hideAlertDialog() }
+                    )
+                }
 
-            NoteHeader(
-                noteCategoryColor = state.noteCategory.getColor(),
-                titleInitialValue = state.title,
-                creationDateValue = noteCreationDate,
-                onTitleChanged = { newTitle ->
-                    viewModel.onTitleUpdate(newTitle)
-                },
-                isNewNote = isNewNote,
-                titleMaxLength = TITLE_MAX_LENGTH.toString(),
-                onTitleDone = { focusRequester.requestFocus() },
-                modifier = Modifier.padding(horizontal = AnoteiAppTheme.spaces.medium)
-            )
-
-            Box(propagateMinConstraints = true) {
-
-                AppPopup(
-                    isPopupVisible = state.showCategoryPopup,
-                    onDismissRequest = { viewModel.hideAlertDialog() },
-                    content = { states, tOrigin ->
-                        NoteCategorySelection(
-                            expandedStates = states,
-                            transformOrigin = tOrigin,
-                            onCategorySelected = { category -> viewModel.updateNoteCategory(category) }
-                        )
-                    }
-                )
-
-                BasicTextField(
-                    value = state.description,
-                    textStyle = TextStyle(
-                        color = AnoteiAppTheme.colors.secondaryTextColor,
-                        fontSize = AnoteiAppTheme.fontSizes.medium,
-                    ),
-                    keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
-                    onValueChange = { newContent ->
-                        viewModel.onDescriptionUpdate(newContent)
+                NoteHeader(
+                    noteCategoryColor = state.noteCategory.getColor(),
+                    titleInitialValue = state.title,
+                    creationDateValue = noteCreationDate,
+                    onTitleChanged = { newTitle ->
+                        viewModel.onTitleUpdate(newTitle)
                     },
-                    cursorBrush = SolidColor(AnoteiAppTheme.colors.colorScheme.secondary),
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(AnoteiAppTheme.spaces.medium)
-                        .focusRequester(focusRequester)
+                    isNewNote = isNewNote,
+                    titleMaxLength = TITLE_MAX_LENGTH.toString(),
+                    isEditModeActivated = state.showEditMode,
+                    focusRequester = focusRequester,
+                    onTitleDone = { },
+                    modifier = Modifier.padding(horizontal = AnoteiAppTheme.spaces.medium)
                 )
+
+                Box(propagateMinConstraints = true) {
+
+                    AppPopup(
+                        isPopupVisible = state.showCategoryPopup,
+                        onDismissRequest = { viewModel.hideAlertDialog() },
+                        content = { states, tOrigin ->
+                            NoteCategorySelection(
+                                expandedStates = states,
+                                transformOrigin = tOrigin,
+                                onCategorySelected = { category ->
+                                    viewModel.updateNoteCategory(
+                                        category
+                                    )
+                                }
+                            )
+                        }
+                    )
+
+                    BasicTextField(
+                        value = state.description,
+                        readOnly = state.showEditMode.not(),
+                        textStyle = TextStyle(
+                            color = AnoteiAppTheme.colors.secondaryTextColor,
+                            fontSize = AnoteiAppTheme.fontSizes.medium,
+                        ),
+                        keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
+                        onValueChange = { newContent ->
+                            viewModel.onDescriptionUpdate(newContent)
+                        },
+                        cursorBrush = SolidColor(AnoteiAppTheme.colors.colorScheme.secondary),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(AnoteiAppTheme.spaces.medium)
+                            .focusRequester(focusRequester)
+                    )
+                }
+            }
+            Button(
+                onClick = {
+                    viewModel.enableEditMode()
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.BottomCenter)
+            )
+            {
+                Text(text = "Editar")
             }
         }
+
     }
 }
 
@@ -209,10 +253,10 @@ private fun isNewNote(noteType: NoteType) = noteType == NoteType.NEW_NOTE
 @Composable
 private fun NoteScreenPreviewLight() {
     AnoteiTheme {
-        NoteScreenContent(
-            noteType = NoteType.NEW_NOTE,
-            note = null,
-            onBackPressed = {}
-        )
+//        NoteScreenContent(
+//            noteType = NoteType.NEW_NOTE,
+//            noteId = null,
+//            // onBackPressed = {}
+//        )
     }
 }

--- a/app/src/main/java/br/com/ascence/anotei/ui/screens/note/NoteScreenState.kt
+++ b/app/src/main/java/br/com/ascence/anotei/ui/screens/note/NoteScreenState.kt
@@ -6,11 +6,13 @@ import br.com.ascence.anotei.model.NoteOption
 data class NoteScreenState(
     val showContentAlert: Boolean = false,
     val showEmptyNoteAlert: Boolean = false,
-    val showNoteDiscardAlert : Boolean = false,
+    val showNoteDiscardAlert: Boolean = false,
     val showCategoryPopup: Boolean = false,
+    val showEditMode: Boolean = false,
     val title: String = "",
     val creationDate: String = "",
     val description: String = "",
+    val descriptionOrTitleHasChanged: Boolean = false,
     val noteCategory: Category = Category.DEFAULT,
-    val noteOptions: List<NoteOption> = emptyList()
+    val noteOptions: List<NoteOption> = emptyList(),
 )

--- a/app/src/main/java/br/com/ascence/anotei/ui/screens/note/components/NoteHeader.kt
+++ b/app/src/main/java/br/com/ascence/anotei/ui/screens/note/components/NoteHeader.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -29,6 +28,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import br.com.ascence.anotei.data.preview.ColorSchemePreviews
 import br.com.ascence.anotei.ui.theme.AnoteiAppTheme
 import br.com.ascence.anotei.ui.theme.AnoteiTheme
+import br.com.ascence.anotei.ui.utils.modifyIfNotNull
 
 @Composable
 fun NoteHeader(
@@ -38,15 +38,15 @@ fun NoteHeader(
     onTitleChanged: (String) -> Unit,
     isNewNote: Boolean,
     titleMaxLength: String,
+    isEditModeActivated: Boolean,
     onTitleDone: () -> Unit,
     modifier: Modifier = Modifier,
+    focusRequester: FocusRequester? = null,
 ) {
 
-    val focusRequester = remember { FocusRequester() }
-
-    LaunchedEffect(Unit) {
+    LaunchedEffect(isNewNote) {
         if (isNewNote) {
-            focusRequester.requestFocus()
+            focusRequester?.requestFocus()
         }
     }
 
@@ -67,50 +67,64 @@ fun NoteHeader(
                     .size(AnoteiAppTheme.spaces.xxxLarge)
             )
 
-            TextField(
-                value = titleInitialValue,
-                onValueChange = onTitleChanged,
-                textStyle = TextStyle(
+            if (isEditModeActivated) {
+
+                TextField(
+                    value = titleInitialValue,
+                    onValueChange = onTitleChanged,
+                    textStyle = TextStyle(
+                        color = AnoteiAppTheme.colors.primaryTextColor,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = AnoteiAppTheme.fontSizes.xLarge,
+                    ),
+                    placeholder = {
+                        Text(
+                            text = "Defina um título",
+                            color = AnoteiAppTheme.colors.accentColor,
+                            fontSize = AnoteiAppTheme.fontSizes.xLarge,
+                            fontWeight = FontWeight.Light,
+                        )
+                    },
+                    supportingText = {
+                        Box(
+                            contentAlignment = Alignment.CenterEnd,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(
+                                text = "${titleInitialValue.length}/$titleMaxLength",
+                                color = AnoteiAppTheme.colors.bottomBarFabColor,
+                                fontSize = AnoteiAppTheme.fontSizes.small,
+                                fontWeight = FontWeight.Normal,
+                            )
+                        }
+                    },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
+                    keyboardActions = KeyboardActions(
+                        onDone = { onTitleDone() }
+                    ),
+                    colors = TextFieldDefaults.colors(
+                        unfocusedContainerColor = AnoteiAppTheme.colors.colorScheme.background,
+                        focusedContainerColor = AnoteiAppTheme.colors.colorScheme.background,
+                        cursorColor = AnoteiAppTheme.colors.colorScheme.secondary,
+                        focusedIndicatorColor = AnoteiAppTheme.colors.bottomBarFabColor,
+                    ),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .modifyIfNotNull(focusRequester) {
+                            focusRequester(it)
+                        }
+                )
+            } else {
+                Text(
+                    text = titleInitialValue,
                     color = AnoteiAppTheme.colors.primaryTextColor,
                     fontWeight = FontWeight.SemiBold,
                     fontSize = AnoteiAppTheme.fontSizes.xLarge,
-                ),
-                placeholder = {
-                    Text(
-                        text = "Defina um título",
-                        color = AnoteiAppTheme.colors.accentColor,
-                        fontSize = AnoteiAppTheme.fontSizes.xLarge,
-                        fontWeight = FontWeight.Light,
-                    )
-                },
-                supportingText = {
-                    Box(
-                        contentAlignment = Alignment.CenterEnd,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text(
-                            text = "${titleInitialValue.length}/$titleMaxLength",
-                            color = AnoteiAppTheme.colors.bottomBarFabColor,
-                            fontSize = AnoteiAppTheme.fontSizes.small,
-                            fontWeight = FontWeight.Normal,
-                        )
-                    }
-                },
-                singleLine = true,
-                keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
-                keyboardActions = KeyboardActions(
-                    onDone = { onTitleDone() }
-                ),
-                colors = TextFieldDefaults.colors(
-                    unfocusedContainerColor = AnoteiAppTheme.colors.colorScheme.background,
-                    focusedContainerColor = AnoteiAppTheme.colors.colorScheme.background,
-                    cursorColor = AnoteiAppTheme.colors.colorScheme.secondary,
-                    focusedIndicatorColor = AnoteiAppTheme.colors.bottomBarFabColor,
-                ),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .focusRequester(focusRequester)
-            )
+                    modifier = Modifier
+                        .padding(horizontal = AnoteiAppTheme.spaces.medium)
+                )
+            }
         }
         Text(
             text = creationDateValue,
@@ -132,6 +146,7 @@ private fun NoteScreenPreviewLight() {
             onTitleChanged = {},
             isNewNote = false,
             titleMaxLength = "40",
+            isEditModeActivated = false,
             onTitleDone = {}
         )
     }

--- a/app/src/main/java/br/com/ascence/anotei/ui/screens/noteDisplay/NoteDisplay.kt
+++ b/app/src/main/java/br/com/ascence/anotei/ui/screens/noteDisplay/NoteDisplay.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -14,7 +16,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import br.com.ascence.anotei.data.local.AnoteiDatabase
 import br.com.ascence.anotei.data.local.implementations.NotesRepositoryImp
 import br.com.ascence.anotei.data.preview.ColorSchemePreviews
@@ -78,6 +83,40 @@ private fun TextNoteDisplayContent(
                         .fillMaxSize()
                         .padding(vertical = AnoteiAppTheme.spaces.medium)
                 )
+                BasicTextField(
+                    value = "Field normal",
+                    textStyle = TextStyle(
+                        color = AnoteiAppTheme.colors.secondaryTextColor,
+                        fontSize = AnoteiAppTheme.fontSizes.medium,
+                    ),
+                    keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
+                    onValueChange = { newContent ->
+                        //viewModel.onDescriptionUpdate(newContent)
+                    },
+                    cursorBrush = SolidColor(AnoteiAppTheme.colors.colorScheme.secondary),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(AnoteiAppTheme.spaces.medium)
+                      //  .focusRequester(focusRequester)
+                )
+                BasicTextField(
+                    value = "Field normal",
+                    readOnly = true,
+                    textStyle = TextStyle(
+                        color = AnoteiAppTheme.colors.secondaryTextColor,
+                        fontSize = AnoteiAppTheme.fontSizes.medium,
+                    ),
+                    keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
+                    onValueChange = { newContent ->
+                        //viewModel.onDescriptionUpdate(newContent)
+                    },
+                    cursorBrush = SolidColor(AnoteiAppTheme.colors.colorScheme.secondary),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(AnoteiAppTheme.spaces.medium)
+                    //  .focusRequester(focusRequester)
+                )
+
             }
         }
     } ?: Box(modifier = Modifier.fillMaxSize()) {


### PR DESCRIPTION
### Pull Request description

Refatorando a tela de Nota pra dar suport pra exibição e edição de notas,

### Visual Evidences

<!--  To set imagens or videos  use
<img width = 300 src ="link of the image">
<video src ="link of the video">
-->

<!-- To set tables use
| column_title | column_title |
| --- | --- |
| row_content | row_content |
| row_content | row_content |
-->



### Checklist before merge

- [x] PR labels set
- [ ] Evidence of changes
- [ ] Unit Tests made (if necessary)
- [ ] UI tests made (if necessary)